### PR TITLE
Feature/admin menu

### DIFF
--- a/autoload/admin-menu.php
+++ b/autoload/admin-menu.php
@@ -1,233 +1,247 @@
 <?php
 
-function filter_pages($page)
-{
-    $default_page_values = [
-        'parent_page' => null,
-        'sub_page' => null,
-    ];
-
-    list('parent_page' => $parent_page, 'sub_page' => $sub_page) = array_merge($default_page_values, $page);
-
-    if ($sub_page && !empty($sub_page)) {
-        return remove_submenu_page(
-            $parent_page,
-            $sub_page
-        );
-    } else {
-        return remove_menu_page(
-            $parent_page
-        );
-    }
+function whitespace_headless_cms_activate_developer_capabilities() {
+  $activate =
+    defined("WHITESPACE_HEADLESS_CMS_ACTIVATE_DEVELOPER_CAPABILITIES") &&
+    WHITESPACE_HEADLESS_CMS_ACTIVATE_DEVELOPER_CAPABILITIES;
+  $activate = apply_filters(
+    "whitespace_headless_cms_activate_developer_capabilities",
+    $activate,
+  );
+  return !!$activate;
 }
 
-function whitespace_headless_cms_hide_admin_page($page)
-{
-    if (defined("WHITESPACE_HEADLESS_CMS_ACTIVATE_DEVELOPER_CAPABILITIES") && WHITESPACE_HEADLESS_CMS_ACTIVATE_DEVELOPER_CAPABILITIES !== FALSE) {
+function filter_pages($page) {
+  $default_page_values = [
+    "parent_page" => null,
+    "sub_page" => null,
+  ];
 
-        return whitespace_headless_cms_hide_admin_pages([$page]);
-    }
+  ["parent_page" => $parent_page, "sub_page" => $sub_page] = array_merge(
+    $default_page_values,
+    $page,
+  );
+
+  if ($sub_page && !empty($sub_page)) {
+    return remove_submenu_page($parent_page, $sub_page);
+  } else {
+    return remove_menu_page($parent_page);
+  }
 }
 
-function whitespace_headless_cms_hide_admin_pages($pages)
-{
-    if (defined("WHITESPACE_HEADLESS_CMS_ACTIVATE_DEVELOPER_CAPABILITIES") && WHITESPACE_HEADLESS_CMS_ACTIVATE_DEVELOPER_CAPABILITIES !== FALSE) {
-
-        add_filter("whitespace_headless_cms_hidden_admin_pages", function ($hidden_admin_pages) use ($pages) {
-            $hidden_admin_pages = array_merge($hidden_admin_pages, $pages);
-            return $hidden_admin_pages;
-        });
-    }
+function whitespace_headless_cms_hide_admin_page($page) {
+  if (whitespace_headless_cms_activate_developer_capabilities()) {
+    return whitespace_headless_cms_hide_admin_pages([$page]);
+  }
 }
 
-function whitespace_headless_cms_unhide_admin_page($page)
-{
-    if (defined("WHITESPACE_HEADLESS_CMS_ACTIVATE_DEVELOPER_CAPABILITIES") && WHITESPACE_HEADLESS_CMS_ACTIVATE_DEVELOPER_CAPABILITIES !== FALSE) {
-
-        return whitespace_headless_cms_unhide_admin_pages([$page]);
-    }
-}
-function whitespace_headless_cms_unhide_admin_pages($pages)
-{
-    if (defined("WHITESPACE_HEADLESS_CMS_ACTIVATE_DEVELOPER_CAPABILITIES") && WHITESPACE_HEADLESS_CMS_ACTIVATE_DEVELOPER_CAPABILITIES !== FALSE) {
-
-        add_filter("whitespace_headless_cms_hidden_admin_pages", function ($hidden_admin_pages) use ($pages) {
-            $admin_pages_to_display = [];
-            foreach ($hidden_admin_pages as $hidden_admin_page) {
-                if (!in_array($hidden_admin_page, $pages)) {
-                    $admin_pages_to_display[] = $hidden_admin_page;
-                };
-            };
-
-            return $admin_pages_to_display;
-        });
-    }
+function whitespace_headless_cms_hide_admin_pages($pages) {
+  if (whitespace_headless_cms_activate_developer_capabilities()) {
+    add_filter("whitespace_headless_cms_hidden_admin_pages", function (
+      $hidden_admin_pages
+    ) use ($pages) {
+      $hidden_admin_pages = array_merge($hidden_admin_pages, $pages);
+      return $hidden_admin_pages;
+    });
+  }
 }
 
+function whitespace_headless_cms_unhide_admin_page($page) {
+  if (whitespace_headless_cms_activate_developer_capabilities()) {
+    return whitespace_headless_cms_unhide_admin_pages([$page]);
+  }
+}
+function whitespace_headless_cms_unhide_admin_pages($pages) {
+  if (whitespace_headless_cms_activate_developer_capabilities()) {
+    add_filter("whitespace_headless_cms_hidden_admin_pages", function (
+      $hidden_admin_pages
+    ) use ($pages) {
+      $admin_pages_to_display = [];
+      foreach ($hidden_admin_pages as $hidden_admin_page) {
+        if (!in_array($hidden_admin_page, $pages)) {
+          $admin_pages_to_display[] = $hidden_admin_page;
+        }
+      }
 
+      return $admin_pages_to_display;
+    });
+  }
+}
 
 /**
  * ADD FILTER TO HIDE OR SHOW ADMIN PAGES
  */
-add_action('admin_init', function () {
-    if (defined("WHITESPACE_HEADLESS_CMS_ACTIVATE_DEVELOPER_CAPABILITIES") && WHITESPACE_HEADLESS_CMS_ACTIVATE_DEVELOPER_CAPABILITIES !== FALSE) {
+add_action("admin_init", function () {
+  if (whitespace_headless_cms_activate_developer_capabilities()) {
+    $hidden_admin_pages = [
+      [
+        "parent_page" => "tools.php",
+      ],
+      [
+        "parent_page" => "options-general.php",
+      ],
+      [
+        "parent_page" => "graphql",
+      ],
+      [
+        "parent_page" => "themes.php",
+        "sub_page" => "themes.php",
+      ],
+      [
+        "parent_page" => "themes.php",
+        "sub_page" => "theme-editor.php",
+      ],
+      [
+        "parent_page" => "themes.php",
+        "sub_page" =>
+          "customize.php?return=" . urlencode($_SERVER["REQUEST_URI"]),
+      ],
+      [
+        "parent_page" => "themes.php",
+        "sub_page" => "widgets.php",
+      ],
+      [
+        "parent_page" => "themes.php",
+        "sub_page" => "acf-options-header",
+      ],
+      [
+        "parent_page" => "themes.php",
+        "sub_page" => "acf-options-footer",
+      ],
+      [
+        "parent_page" => "themes.php",
+        "sub_page" => "acf-options-archives",
+      ],
+      [
+        "parent_page" => "themes.php",
+        "sub_page" => "acf-options-404",
+      ],
+      [
+        "parent_page" => "themes.php",
+        "sub_page" => "acf-options-taxonomies",
+      ],
+      [
+        "parent_page" => "themes.php",
+        "sub_page" => "acf-options-post-types",
+      ],
+      [
+        "parent_page" => "themes.php",
+        "sub_page" => "acf-options-content-editor",
+      ],
+      [
+        "parent_page" => "themes.php",
+        "sub_page" => "acf-options-content",
+      ],
+      [
+        "parent_page" => "themes.php",
+        "sub_page" => "acf-options-navigation",
+      ],
+      [
+        "parent_page" => "themes.php",
+        "sub_page" => "acf-options-google-translate",
+      ],
+      [
+        "parent_page" => "themes.php",
+        "sub_page" => "acf-options-css",
+      ],
+    ];
 
-        $hidden_admin_pages = [
-            [
-                "parent_page" => "tools.php",
-            ],
-            [
-                "parent_page" => "options-general.php",
+    $hidden_admin_pages = apply_filters(
+      "whitespace_headless_cms_hidden_admin_pages",
+      $hidden_admin_pages,
+    );
 
-            ],
-            [
-                "parent_page" => "graphql",
-            ],
-            [
-                "parent_page" => "themes.php",
-                "sub_page" => "themes.php"
-            ],
-            [
-                "parent_page" => "themes.php",
-                "sub_page" => "theme-editor.php"
-            ],
-            [
-                "parent_page" => "themes.php",
-                "sub_page" => "customize.php?return=" .  urlencode($_SERVER['REQUEST_URI'])
-            ],
-            [
-                "parent_page" => "themes.php",
-                "sub_page" => "widgets.php"
-            ],
-            [
-                "parent_page" => "themes.php",
-                "sub_page" => "acf-options-header"
-            ],
-            [
-                "parent_page" => "themes.php",
-                "sub_page" => "acf-options-footer"
-            ],
-            [
-                "parent_page" => "themes.php",
-                "sub_page" => "acf-options-archives"
-            ],
-            [
-                "parent_page" => "themes.php",
-                "sub_page" => "acf-options-404"
-            ],
-            [
-                "parent_page" => "themes.php",
-                "sub_page" => "acf-options-taxonomies"
-            ],
-            [
-                "parent_page" => "themes.php",
-                "sub_page" => "acf-options-post-types"
-            ],
-            [
-                "parent_page" => "themes.php",
-                "sub_page" => "acf-options-content-editor"
-            ],
-            [
-                "parent_page" => "themes.php",
-                "sub_page" => "acf-options-content"
-            ],
-            [
-                "parent_page" => "themes.php",
-                "sub_page" => "acf-options-navigation"
-            ],
-            [
-                "parent_page" => "themes.php",
-                "sub_page" => "acf-options-google-translate"
-            ],
-            [
-                "parent_page" => "themes.php",
-                "sub_page" => "acf-options-css"
-            ]
-        ];
-
-        $hidden_admin_pages = apply_filters("whitespace_headless_cms_hidden_admin_pages", $hidden_admin_pages);
-
-        if (!current_user_can('manage_dev_options')) {
-            foreach ($hidden_admin_pages as $key => $page) {
-                filter_pages($page);
-            }
-        }
+    if (!current_user_can("manage_dev_options")) {
+      foreach ($hidden_admin_pages as $key => $page) {
+        filter_pages($page);
+      }
     }
+  }
 });
 
 /* CREATE USER ROLE DEVELOPER */
-add_action('admin_init', function () {
-    if (defined("WHITESPACE_HEADLESS_CMS_ACTIVATE_DEVELOPER_CAPABILITIES") && WHITESPACE_HEADLESS_CMS_ACTIVATE_DEVELOPER_CAPABILITIES !== FALSE) {
+add_action(
+  "admin_init",
+  function () {
+    if (whitespace_headless_cms_activate_developer_capabilities()) {
+      $dev = $GLOBALS["wp_roles"]->is_role("developer");
 
-        $dev = $GLOBALS['wp_roles']->is_role('developer');
+      if ($dev) {
+        return;
+      }
 
-        if ($dev) return;
+      $dev_cap = array_merge(
+        get_role("administrator")->capabilities,
+        ["manage_dev_options" => true],
+        ["administrator" => true],
+      );
 
-        $dev_cap = array_merge(get_role('administrator')->capabilities, ['manage_dev_options' => true], ["administrator" => true]);
-
-        add_role('developer', __('Developer', 'whitespace-headless-cms'),  $dev_cap);
+      add_role(
+        "developer",
+        __("Developer", "whitespace-headless-cms"),
+        $dev_cap,
+      );
     }
-}, 99);
-
-
+  },
+  99,
+);
 
 /* REMOVE SELECTED CAPABILITIES FROM ALL USER ROLES BUT DEVELOPER */
-add_action('admin_init', function () {
-    if (defined("WHITESPACE_HEADLESS_CMS_ACTIVATE_DEVELOPER_CAPABILITIES") && WHITESPACE_HEADLESS_CMS_ACTIVATE_DEVELOPER_CAPABILITIES !== FALSE) {
+add_action("admin_init", function () {
+  if (whitespace_headless_cms_activate_developer_capabilities()) {
+    $caps_to_remove = [
+      "update_core",
+      "update_plugins",
+      "update_themes",
+      "install_plugins",
+      "install_themes",
+      "edit_themes",
+      "delete_themes",
+      "delete_plugins",
+      "edit_plugins",
+      "manage_options",
+      "activate_plugins",
+      "export",
+      "import",
+      "switch_themes",
+      "customize",
+      "delete_site",
+    ];
 
-        $caps_to_remove = [
-            'update_core',
-            'update_plugins',
-            'update_themes',
-            'install_plugins',
-            'install_themes',
-            'edit_themes',
-            'delete_themes',
-            'delete_plugins',
-            'edit_plugins',
-            'manage_options',
-            'activate_plugins',
-            'export',
-            'import',
-            'switch_themes',
-            'customize',
-            'delete_site'
-        ];
+    global $wp_roles;
 
-        global $wp_roles;
+    foreach ($wp_roles->roles as $wp_role) {
+      $wp_role_name = strtolower($wp_role["name"]);
 
-        foreach ($wp_roles->roles as $wp_role) {
-            $wp_role_name = strtolower($wp_role['name']);
+      if ($wp_role_name === "developer") {
+        break;
+      }
 
-            if ($wp_role_name === "developer") break;
-
-            foreach ($caps_to_remove as $cap) {
-                if (isset($wp_role['capabilities'][$cap])) {
-                    $role = get_role($wp_role_name);
-                    $role->remove_cap($cap);
-                }
-            }
+      foreach ($caps_to_remove as $cap) {
+        if (isset($wp_role["capabilities"][$cap])) {
+          $role = get_role($wp_role_name);
+          $role->remove_cap($cap);
         }
-
-        $role = get_role('developer');
-        foreach ($caps_to_remove as $cap) {
-            $role->add_cap($cap);
-        }
+      }
     }
-});
 
+    $role = get_role("developer");
+    foreach ($caps_to_remove as $cap) {
+      $role->add_cap($cap);
+    }
+  }
+});
 
 /* Hide acf settings for non developers */
-add_filter('acf/settings/show_admin', function () {
-    if (defined("WHITESPACE_HEADLESS_CMS_ACTIVATE_DEVELOPER_CAPABILITIES") && WHITESPACE_HEADLESS_CMS_ACTIVATE_DEVELOPER_CAPABILITIES !== FALSE) {
-        return current_user_can('manage_dev_options');
-    }
+add_filter("acf/settings/show_admin", function () {
+  if (whitespace_headless_cms_activate_developer_capabilities()) {
+    return current_user_can("manage_dev_options");
+  }
 });
 
-add_action('whitespace_headless_cms/activate', function () {
-    if (defined("WHITESPACE_HEADLESS_CMS_ACTIVATE_DEVELOPER_CAPABILITIES") && WHITESPACE_HEADLESS_CMS_ACTIVATE_DEVELOPER_CAPABILITIES !== FALSE) {
-
-        $user = wp_get_current_user();
-        $user->set_role('developer');
-    }
+add_action("whitespace_headless_cms/activate", function () {
+  if (whitespace_headless_cms_activate_developer_capabilities()) {
+    $user = wp_get_current_user();
+    $user->set_role("developer");
+  }
 });

--- a/autoload/admin-menu.php
+++ b/autoload/admin-menu.php
@@ -1,0 +1,80 @@
+/* CREATE USER ROLE DEVELOPER */
+add_action('admin_init', function() {
+
+$dev = $GLOBALS['wp_roles']->is_role( 'developer' );
+
+if($dev) return;
+
+$dev_cap = array_merge(get_role( 'administrator' )->capabilities, ['devop' => true]);
+
+add_role( 'developer', __('Developer', 'whitespace-headless-cms'), $dev_cap);
+});
+
+
+
+/* REMOVE SELECTED CAPABILITIES FROM ALL USER ROLES BUT DEVELOPER */
+add_action('admin_init', function() {
+
+$caps_to_remove = ['update_core',
+'update_plugins',
+'update_themes',
+'install_plugins',
+'install_themes',
+'edit_themes',
+'delete_themes',
+'delete_plugins',
+'edit_plugins',
+'activate_plugins',
+'export',
+'import',
+'manage_options',
+'switch_themes',
+'customize',
+'delete_site'
+];
+
+global $wp_roles;
+
+foreach($wp_roles->roles as $wp_role) {
+$wp_role_name = strtolower($wp_role['name']);
+
+if($wp_role_name === "developer") return;
+
+foreach ( $caps_to_remove as $cap ) {
+if(isset($wp_role['capabilities'][$cap])) {
+$role = get_role($wp_role_name);
+$role->remove_cap($cap);
+}
+}
+}
+
+
+});
+
+
+/* if current user isn't developer add this custom filter to block them from seeings some pages */
+add_action('admin_init', function() {
+if ( !current_user_can( 'devop' ) ) {
+
+remove_menu_page("tools.php");
+
+remove_submenu_page(
+"themes.php",
+"themes.php"
+);
+
+// remove_submenu_page(
+// "themes.php",
+// "customize.php?return=%2Fwp-admin%2Fedit.php%3Fpost_type%3Devent_place"
+// );
+
+remove_submenu_page(
+"themes.php",
+"widgets.php"
+);
+
+
+// add_filter( 'show_admin_bar', '__return_false' );
+}
+
+});

--- a/autoload/admin-menu.php
+++ b/autoload/admin-menu.php
@@ -1,80 +1,201 @@
+<?php
+
+function filter_pages($page, $page_to_compare = null, $function = 'filter')
+{
+    $default_page_values = [
+        'parent_page' => null,
+        'sub_page' => null,
+        'action' => "hide"
+    ];
+
+    list('parent_page' => $parent_page, 'sub_page' => $sub_page, 'action' => $action) = array_merge($default_page_values, $page);
+
+    if ($function == "filter") {
+        switch ($action) {
+            case "show":
+                if ($sub_page && !empty($page_to_compare['sub_page'])) {
+                    return $page_to_compare['sub_page'] !== $sub_page;
+                } else {
+                    return $page_to_compare['parent_page'] !== $parent_page;
+                }
+            default:
+                return $page_to_compare;
+        }
+    } else if ($function == "hide") {
+        switch ($action) {
+            case "show":
+                return;
+            default:
+                if ($sub_page && !empty($sub_page)) {
+                    return remove_submenu_page(
+                        $parent_page,
+                        $sub_page
+                    );
+                } else {
+                    return remove_menu_page(
+                        $parent_page
+                    );
+                }
+        }
+    }
+}
+
+
+/**
+ * ADD FILTER TO HIDE OR SHOW ADMIN PAGES
+ */
+
+add_filter("whitespace_headless_cms_filter_admin_pages", function ($pages = []) {
+    $default_pages_to_filter = [
+        [
+            "parent_page" => "tools.php",
+        ],
+        [
+            "parent_page" => "options-general.php",
+
+        ],
+        [
+            "parent_page" => "graphql",
+        ],
+        [
+            "parent_page" => "themes.php",
+            "sub_page" => "themes.php"
+        ],
+        [
+            "parent_page" => "themes.php",
+            "sub_page" => "theme-editor.php"
+        ],
+        [
+            "parent_page" => "themes.php",
+            "sub_page" => "customize.php?return=" .  urlencode($_SERVER['REQUEST_URI'])
+        ],
+        [
+            "parent_page" => "themes.php",
+            "sub_page" => "widgets.php"
+        ],
+        [
+            "parent_page" => "themes.php",
+            "sub_page" => "acf-options-header"
+        ],
+        [
+            "parent_page" => "themes.php",
+            "sub_page" => "acf-options-footer"
+        ],
+        [
+            "parent_page" => "themes.php",
+            "sub_page" => "acf-options-archives"
+        ],
+        [
+            "parent_page" => "themes.php",
+            "sub_page" => "acf-options-404"
+        ],
+        [
+            "parent_page" => "themes.php",
+            "sub_page" => "acf-options-taxonomies"
+        ],
+        [
+            "parent_page" => "themes.php",
+            "sub_page" => "acf-options-post-types"
+        ],
+        [
+            "parent_page" => "themes.php",
+            "sub_page" => "acf-options-content-editor"
+        ],
+        [
+            "parent_page" => "themes.php",
+            "sub_page" => "acf-options-content"
+        ],
+        [
+            "parent_page" => "themes.php",
+            "sub_page" => "acf-options-navigation"
+        ],
+        [
+            "parent_page" => "themes.php",
+            "sub_page" => "acf-options-google-translate"
+        ],
+        [
+            "parent_page" => "themes.php",
+            "sub_page" => "acf-options-css"
+        ]
+    ];
+
+    if (!current_user_can('manage_dev_options')) {
+
+        if (isset($pages)) {
+
+            foreach ($pages as $key => $page) {
+                $default_pages_to_filter = array_filter($default_pages_to_filter, function ($default_page_to_filter) use ($page) {
+                    return filter_pages($page, $default_page_to_filter, 'filter');
+                });
+            }
+
+            $default_pages_to_filter = array_merge($default_pages_to_filter, $pages);
+        }
+
+
+
+        foreach ($default_pages_to_filter as $key => $default_page_to_filter) {
+            filter_pages($default_page_to_filter, null, 'hide');
+        }
+    }
+}, 10, 1);
+
+
+
 /* CREATE USER ROLE DEVELOPER */
-add_action('admin_init', function() {
+add_action('admin_init', function () {
 
-$dev = $GLOBALS['wp_roles']->is_role( 'developer' );
+    $dev = $GLOBALS['wp_roles']->is_role('developer');
 
-if($dev) return;
+    if ($dev) return;
 
-$dev_cap = array_merge(get_role( 'administrator' )->capabilities, ['devop' => true]);
+    $dev_cap = array_merge(get_role('administrator')->capabilities, ['manage_dev_options' => true], ["administrator" => true]);
 
-add_role( 'developer', __('Developer', 'whitespace-headless-cms'), $dev_cap);
-});
+    add_role('developer', __('Developer', 'whitespace-headless-cms'),  $dev_cap);
+}, 99);
 
 
 
 /* REMOVE SELECTED CAPABILITIES FROM ALL USER ROLES BUT DEVELOPER */
-add_action('admin_init', function() {
+add_action('admin_init', function () {
 
-$caps_to_remove = ['update_core',
-'update_plugins',
-'update_themes',
-'install_plugins',
-'install_themes',
-'edit_themes',
-'delete_themes',
-'delete_plugins',
-'edit_plugins',
-'activate_plugins',
-'export',
-'import',
-'manage_options',
-'switch_themes',
-'customize',
-'delete_site'
-];
+    $caps_to_remove = [
+        'update_core',
+        'update_plugins',
+        'update_themes',
+        'install_plugins',
+        'install_themes',
+        'edit_themes',
+        'delete_themes',
+        'delete_plugins',
+        'edit_plugins',
+        'manage_options',
+        'activate_plugins',
+        'export',
+        'import',
+        'switch_themes',
+        'customize',
+        'delete_site'
+    ];
 
-global $wp_roles;
+    global $wp_roles;
 
-foreach($wp_roles->roles as $wp_role) {
-$wp_role_name = strtolower($wp_role['name']);
+    foreach ($wp_roles->roles as $wp_role) {
+        $wp_role_name = strtolower($wp_role['name']);
 
-if($wp_role_name === "developer") return;
+        if ($wp_role_name === "developer") return;
 
-foreach ( $caps_to_remove as $cap ) {
-if(isset($wp_role['capabilities'][$cap])) {
-$role = get_role($wp_role_name);
-$role->remove_cap($cap);
-}
-}
-}
-
-
+        foreach ($caps_to_remove as $cap) {
+            if (isset($wp_role['capabilities'][$cap])) {
+                $role = get_role($wp_role_name);
+                $role->remove_cap($cap);
+            }
+        }
+    }
 });
 
 
-/* if current user isn't developer add this custom filter to block them from seeings some pages */
-add_action('admin_init', function() {
-if ( !current_user_can( 'devop' ) ) {
-
-remove_menu_page("tools.php");
-
-remove_submenu_page(
-"themes.php",
-"themes.php"
-);
-
-// remove_submenu_page(
-// "themes.php",
-// "customize.php?return=%2Fwp-admin%2Fedit.php%3Fpost_type%3Devent_place"
-// );
-
-remove_submenu_page(
-"themes.php",
-"widgets.php"
-);
-
-
-// add_filter( 'show_admin_bar', '__return_false' );
-}
-
+/* Hide acf settings for non developers */
+add_filter('acf/settings/show_admin', function () {
+    return current_user_can('manage_dev_options');
 });

--- a/autoload/admin-menu.php
+++ b/autoload/admin-menu.php
@@ -23,33 +23,45 @@ function filter_pages($page)
 
 function whitespace_headless_cms_hide_admin_page($page)
 {
-    return whitespace_headless_cms_hide_admin_pages([$page]);
+    if (defined("WHITESPACE_HEADLESS_CMS_ACTIVATE_DEVELOPER_CAPABILITIES") && WHITESPACE_HEADLESS_CMS_ACTIVATE_DEVELOPER_CAPABILITIES !== FALSE) {
+
+        return whitespace_headless_cms_hide_admin_pages([$page]);
+    }
 }
 
 function whitespace_headless_cms_hide_admin_pages($pages)
 {
-    add_filter("whitespace_headless_cms_hidden_admin_pages", function ($hidden_admin_pages) use ($pages) {
-        $hidden_admin_pages = array_merge($hidden_admin_pages, $pages);
-        return $hidden_admin_pages;
-    });
+    if (defined("WHITESPACE_HEADLESS_CMS_ACTIVATE_DEVELOPER_CAPABILITIES") && WHITESPACE_HEADLESS_CMS_ACTIVATE_DEVELOPER_CAPABILITIES !== FALSE) {
+
+        add_filter("whitespace_headless_cms_hidden_admin_pages", function ($hidden_admin_pages) use ($pages) {
+            $hidden_admin_pages = array_merge($hidden_admin_pages, $pages);
+            return $hidden_admin_pages;
+        });
+    }
 }
 
 function whitespace_headless_cms_unhide_admin_page($page)
 {
-    return whitespace_headless_cms_unhide_admin_pages([$page]);
+    if (defined("WHITESPACE_HEADLESS_CMS_ACTIVATE_DEVELOPER_CAPABILITIES") && WHITESPACE_HEADLESS_CMS_ACTIVATE_DEVELOPER_CAPABILITIES !== FALSE) {
+
+        return whitespace_headless_cms_unhide_admin_pages([$page]);
+    }
 }
 function whitespace_headless_cms_unhide_admin_pages($pages)
 {
-    add_filter("whitespace_headless_cms_hidden_admin_pages", function ($hidden_admin_pages) use ($pages) {
-        $admin_pages_to_display = [];
-        foreach ($hidden_admin_pages as $hidden_admin_page) {
-            if (!in_array($hidden_admin_page, $pages)) {
-                $admin_pages_to_display[] = $hidden_admin_page;
-            };
-        };
+    if (defined("WHITESPACE_HEADLESS_CMS_ACTIVATE_DEVELOPER_CAPABILITIES") && WHITESPACE_HEADLESS_CMS_ACTIVATE_DEVELOPER_CAPABILITIES !== FALSE) {
 
-        return $admin_pages_to_display;
-    });
+        add_filter("whitespace_headless_cms_hidden_admin_pages", function ($hidden_admin_pages) use ($pages) {
+            $admin_pages_to_display = [];
+            foreach ($hidden_admin_pages as $hidden_admin_page) {
+                if (!in_array($hidden_admin_page, $pages)) {
+                    $admin_pages_to_display[] = $hidden_admin_page;
+                };
+            };
+
+            return $admin_pages_to_display;
+        });
+    }
 }
 
 
@@ -58,152 +70,164 @@ function whitespace_headless_cms_unhide_admin_pages($pages)
  * ADD FILTER TO HIDE OR SHOW ADMIN PAGES
  */
 add_action('admin_init', function () {
-    $hidden_admin_pages = [
-        [
-            "parent_page" => "tools.php",
-        ],
-        [
-            "parent_page" => "options-general.php",
+    if (defined("WHITESPACE_HEADLESS_CMS_ACTIVATE_DEVELOPER_CAPABILITIES") && WHITESPACE_HEADLESS_CMS_ACTIVATE_DEVELOPER_CAPABILITIES !== FALSE) {
 
-        ],
-        [
-            "parent_page" => "graphql",
-        ],
-        [
-            "parent_page" => "themes.php",
-            "sub_page" => "themes.php"
-        ],
-        [
-            "parent_page" => "themes.php",
-            "sub_page" => "theme-editor.php"
-        ],
-        [
-            "parent_page" => "themes.php",
-            "sub_page" => "customize.php?return=" .  urlencode($_SERVER['REQUEST_URI'])
-        ],
-        [
-            "parent_page" => "themes.php",
-            "sub_page" => "widgets.php"
-        ],
-        [
-            "parent_page" => "themes.php",
-            "sub_page" => "acf-options-header"
-        ],
-        [
-            "parent_page" => "themes.php",
-            "sub_page" => "acf-options-footer"
-        ],
-        [
-            "parent_page" => "themes.php",
-            "sub_page" => "acf-options-archives"
-        ],
-        [
-            "parent_page" => "themes.php",
-            "sub_page" => "acf-options-404"
-        ],
-        [
-            "parent_page" => "themes.php",
-            "sub_page" => "acf-options-taxonomies"
-        ],
-        [
-            "parent_page" => "themes.php",
-            "sub_page" => "acf-options-post-types"
-        ],
-        [
-            "parent_page" => "themes.php",
-            "sub_page" => "acf-options-content-editor"
-        ],
-        [
-            "parent_page" => "themes.php",
-            "sub_page" => "acf-options-content"
-        ],
-        [
-            "parent_page" => "themes.php",
-            "sub_page" => "acf-options-navigation"
-        ],
-        [
-            "parent_page" => "themes.php",
-            "sub_page" => "acf-options-google-translate"
-        ],
-        [
-            "parent_page" => "themes.php",
-            "sub_page" => "acf-options-css"
-        ]
-    ];
+        $hidden_admin_pages = [
+            [
+                "parent_page" => "tools.php",
+            ],
+            [
+                "parent_page" => "options-general.php",
 
-    $hidden_admin_pages = apply_filters("whitespace_headless_cms_hidden_admin_pages", $hidden_admin_pages);
+            ],
+            [
+                "parent_page" => "graphql",
+            ],
+            [
+                "parent_page" => "themes.php",
+                "sub_page" => "themes.php"
+            ],
+            [
+                "parent_page" => "themes.php",
+                "sub_page" => "theme-editor.php"
+            ],
+            [
+                "parent_page" => "themes.php",
+                "sub_page" => "customize.php?return=" .  urlencode($_SERVER['REQUEST_URI'])
+            ],
+            [
+                "parent_page" => "themes.php",
+                "sub_page" => "widgets.php"
+            ],
+            [
+                "parent_page" => "themes.php",
+                "sub_page" => "acf-options-header"
+            ],
+            [
+                "parent_page" => "themes.php",
+                "sub_page" => "acf-options-footer"
+            ],
+            [
+                "parent_page" => "themes.php",
+                "sub_page" => "acf-options-archives"
+            ],
+            [
+                "parent_page" => "themes.php",
+                "sub_page" => "acf-options-404"
+            ],
+            [
+                "parent_page" => "themes.php",
+                "sub_page" => "acf-options-taxonomies"
+            ],
+            [
+                "parent_page" => "themes.php",
+                "sub_page" => "acf-options-post-types"
+            ],
+            [
+                "parent_page" => "themes.php",
+                "sub_page" => "acf-options-content-editor"
+            ],
+            [
+                "parent_page" => "themes.php",
+                "sub_page" => "acf-options-content"
+            ],
+            [
+                "parent_page" => "themes.php",
+                "sub_page" => "acf-options-navigation"
+            ],
+            [
+                "parent_page" => "themes.php",
+                "sub_page" => "acf-options-google-translate"
+            ],
+            [
+                "parent_page" => "themes.php",
+                "sub_page" => "acf-options-css"
+            ]
+        ];
 
-    if (!current_user_can('manage_dev_options')) {
-        foreach ($hidden_admin_pages as $key => $page) {
-            filter_pages($page);
+        $hidden_admin_pages = apply_filters("whitespace_headless_cms_hidden_admin_pages", $hidden_admin_pages);
+
+        if (!current_user_can('manage_dev_options')) {
+            foreach ($hidden_admin_pages as $key => $page) {
+                filter_pages($page);
+            }
         }
     }
 });
 
 /* CREATE USER ROLE DEVELOPER */
 add_action('admin_init', function () {
+    if (defined("WHITESPACE_HEADLESS_CMS_ACTIVATE_DEVELOPER_CAPABILITIES") && WHITESPACE_HEADLESS_CMS_ACTIVATE_DEVELOPER_CAPABILITIES !== FALSE) {
 
-    $dev = $GLOBALS['wp_roles']->is_role('developer');
+        $dev = $GLOBALS['wp_roles']->is_role('developer');
 
-    if ($dev) return;
+        if ($dev) return;
 
-    $dev_cap = array_merge(get_role('administrator')->capabilities, ['manage_dev_options' => true], ["administrator" => true]);
+        $dev_cap = array_merge(get_role('administrator')->capabilities, ['manage_dev_options' => true], ["administrator" => true]);
 
-    add_role('developer', __('Developer', 'whitespace-headless-cms'),  $dev_cap);
+        add_role('developer', __('Developer', 'whitespace-headless-cms'),  $dev_cap);
+    }
 }, 99);
 
 
 
 /* REMOVE SELECTED CAPABILITIES FROM ALL USER ROLES BUT DEVELOPER */
 add_action('admin_init', function () {
+    if (defined("WHITESPACE_HEADLESS_CMS_ACTIVATE_DEVELOPER_CAPABILITIES") && WHITESPACE_HEADLESS_CMS_ACTIVATE_DEVELOPER_CAPABILITIES !== FALSE) {
 
-    $caps_to_remove = [
-        'update_core',
-        'update_plugins',
-        'update_themes',
-        'install_plugins',
-        'install_themes',
-        'edit_themes',
-        'delete_themes',
-        'delete_plugins',
-        'edit_plugins',
-        'manage_options',
-        'activate_plugins',
-        'export',
-        'import',
-        'switch_themes',
-        'customize',
-        'delete_site'
-    ];
+        $caps_to_remove = [
+            'update_core',
+            'update_plugins',
+            'update_themes',
+            'install_plugins',
+            'install_themes',
+            'edit_themes',
+            'delete_themes',
+            'delete_plugins',
+            'edit_plugins',
+            'manage_options',
+            'activate_plugins',
+            'export',
+            'import',
+            'switch_themes',
+            'customize',
+            'delete_site'
+        ];
 
-    global $wp_roles;
+        global $wp_roles;
 
-    foreach ($wp_roles->roles as $wp_role) {
-        $wp_role_name = strtolower($wp_role['name']);
+        foreach ($wp_roles->roles as $wp_role) {
+            $wp_role_name = strtolower($wp_role['name']);
 
-        if ($wp_role_name === "developer") break;
+            if ($wp_role_name === "developer") break;
 
-        foreach ($caps_to_remove as $cap) {
-            if (isset($wp_role['capabilities'][$cap])) {
-                $role = get_role($wp_role_name);
-                $role->remove_cap($cap);
+            foreach ($caps_to_remove as $cap) {
+                if (isset($wp_role['capabilities'][$cap])) {
+                    $role = get_role($wp_role_name);
+                    $role->remove_cap($cap);
+                }
             }
         }
-    }
 
-    $role = get_role('developer');
-    foreach ($caps_to_remove as $cap) {
+        $role = get_role('developer');
+        foreach ($caps_to_remove as $cap) {
             $role->add_cap($cap);
+        }
     }
 });
 
 
 /* Hide acf settings for non developers */
 add_filter('acf/settings/show_admin', function () {
-    return current_user_can('manage_dev_options');
+    if (defined("WHITESPACE_HEADLESS_CMS_ACTIVATE_DEVELOPER_CAPABILITIES") && WHITESPACE_HEADLESS_CMS_ACTIVATE_DEVELOPER_CAPABILITIES !== FALSE) {
+        return current_user_can('manage_dev_options');
+    }
 });
 
-add_action('whitespace_headless_cms/activate', function() {
-  $user = wp_get_current_user();
-  $user->set_role('developer');
+add_action('whitespace_headless_cms/activate', function () {
+    if (defined("WHITESPACE_HEADLESS_CMS_ACTIVATE_DEVELOPER_CAPABILITIES") && WHITESPACE_HEADLESS_CMS_ACTIVATE_DEVELOPER_CAPABILITIES !== FALSE) {
+
+        $user = wp_get_current_user();
+        $user->set_role('developer');
+    }
 });

--- a/autoload/admin-menu.php
+++ b/autoload/admin-menu.php
@@ -202,3 +202,8 @@ add_action('admin_init', function () {
 add_filter('acf/settings/show_admin', function () {
     return current_user_can('manage_dev_options');
 });
+
+add_action('whitespace_headless_cms/activate', function() {
+  $user = wp_get_current_user();
+  $user->set_role('developer');
+});

--- a/autoload/admin-menu.php
+++ b/autoload/admin-menu.php
@@ -181,7 +181,7 @@ add_action('admin_init', function () {
     foreach ($wp_roles->roles as $wp_role) {
         $wp_role_name = strtolower($wp_role['name']);
 
-        if ($wp_role_name === "developer") return;
+        if ($wp_role_name === "developer") break;
 
         foreach ($caps_to_remove as $cap) {
             if (isset($wp_role['capabilities'][$cap])) {
@@ -189,6 +189,11 @@ add_action('admin_init', function () {
                 $role->remove_cap($cap);
             }
         }
+    }
+
+    $role = get_role('developer');
+    foreach ($caps_to_remove as $cap) {
+            $role->add_cap($cap);
     }
 });
 

--- a/autoload/setup.php
+++ b/autoload/setup.php
@@ -1,0 +1,18 @@
+<?php
+
+function whitespace_headless_cms_activate() {
+  add_option("whitespace_headless_cms_activated", true);
+}
+
+add_action("admin_init", function () {
+  if (empty(get_option("whitespace_headless_cms_activated"))) {
+    return;
+  }
+  do_action("whitespace_headless_cms/activate");
+  delete_option("whitespace_headless_cms_activated");
+});
+
+register_activation_hook(
+  WHITESPACE_HEADLESS_CMS_PLUGIN_FILE,
+  "whitespace_headless_cms_activate",
+);


### PR DESCRIPTION
This PR does a few things:

1. It adds a new role called `developer`.
2. It moves some caps from `administrator` (and all other roles) to ` developer`
3. It hides some admin pages for users without the `developer` role by assigning a new `manage_dev_options` cap to them.
4. It changes role to `developer` for the user that activates the plugin (or is the first to log in, if mu-plugin)

What pages are hidden/displayed can be changed via the `whitespace_headless_cms_hidden_admin_pages` filter and the functions: `whitespace_headless_cms_hide_admin_pages`, `whitespace_headless_cms_unhide_admin_pages`